### PR TITLE
Fix `Synchronized` tag comparation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,9 +12,15 @@ let package = Package(
     targets: [
         .target(
             name: "Toggl2Redmine",
+            dependencies: ["Toggl2RedmineCore"]),
+        .target(
+            name: "Toggl2RedmineCore",
             dependencies: []),
         .testTarget(
             name: "Toggl2RedmineTests",
             dependencies: ["Toggl2Redmine"]),
+        .testTarget(
+            name: "Toggl2RedmineCoreTests",
+            dependencies: ["Toggl2RedmineCore"]),
     ]
 )

--- a/Sources/Toggl2Redmine/main.swift
+++ b/Sources/Toggl2Redmine/main.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Toggl2RedmineCore
 
 let kAutotrackerTag = "autotracker"
 

--- a/Sources/Toggl2RedmineCore/Models/RedmineEntry.swift
+++ b/Sources/Toggl2RedmineCore/Models/RedmineEntry.swift
@@ -8,26 +8,26 @@
 
 import Foundation
 
-class RedmineEntry {
-    let issueID: Int
-    var duration: Int
-    var comments: [String]
-    let spentOn: String
+public class RedmineEntry {
+    public let issueID: Int
+    public var duration: Int
+    public var comments: [String]
+    public let spentOn: String
 
-    init(issueID: Int, duration: Int = 0, comments: [String] = [], spentOn: String) {
+    public init(issueID: Int, duration: Int = 0, comments: [String] = [], spentOn: String) {
         self.issueID = issueID
         self.duration = duration
         self.comments = comments
         self.spentOn = spentOn
     }
 
-    func addComment(_ comment: String) {
+    public func addComment(_ comment: String) {
         guard comments.contains(comment) == false else { return }
         comments.append(comment)
     }
 }
 
-extension RedmineEntry {
+public extension RedmineEntry {
     var hours: Double {
         Double(duration) / 3600
     }
@@ -38,7 +38,7 @@ extension RedmineEntry {
 }
 
 extension RedmineEntry: CustomStringConvertible {
-    var description: String {
+    public var description: String {
         "\(issueID): \(hours) (\(duration) m), \(formattedComments), \(spentOn)"
     }
 }

--- a/Sources/Toggl2RedmineCore/Models/TogglEntry.swift
+++ b/Sources/Toggl2RedmineCore/Models/TogglEntry.swift
@@ -8,18 +8,26 @@
 
 import Foundation
 
-let kSynchronizedTag = "Synchronized"
+public let kSynchronizedTag = "Synchronized"
 
-struct TogglEntry {
-    let id: Int
-    let description: String
-    let start: Date
-    let duration: Int
-    let tags: [String]
+public struct TogglEntry {
+    public let id: Int
+    public let description: String
+    public let start: Date
+    public let duration: Int
+    public let tags: [String]
+    
+    public init(id: Int, description: String, start: Date, duration: Int, tags: [String]) {
+        self.id = id
+        self.description = description
+        self.start = start
+        self.duration = duration
+        self.tags = tags
+    }
 }
 
 extension TogglEntry: Codable {
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try! decoder.container(keyedBy: CodingKeys.self)
         id = try! container.decode(Int.self, forKey: .id)
         let description = try! container.decodeIfPresent(String.self, forKey: .description)
@@ -31,7 +39,7 @@ extension TogglEntry: Codable {
     }
 }
 
-extension TogglEntry {
+public extension TogglEntry {
     var issueID: Int? {
         let pattern = "#([0-9]+):"
         guard let range = description.range(of: pattern, options: .regularExpression) else { return nil }
@@ -45,6 +53,7 @@ extension TogglEntry {
     }
 
     var isValid: Bool {
+//        issueID != nil && tags.contains(kSynchronizedTag) == false && duration > 0
         issueID != nil && tags.contains(kSynchronizedTag) == false && duration > 0
     }
 }

--- a/Sources/Toggl2RedmineCore/Models/TogglEntry.swift
+++ b/Sources/Toggl2RedmineCore/Models/TogglEntry.swift
@@ -53,7 +53,6 @@ public extension TogglEntry {
     }
 
     var isValid: Bool {
-//        issueID != nil && tags.contains(kSynchronizedTag) == false && duration > 0
-        issueID != nil && tags.contains(kSynchronizedTag) == false && duration > 0
+        issueID != nil && tags.contains { $0.lowercased() == kSynchronizedTag.lowercased() } == false && duration > 0
     }
 }

--- a/Tests/Toggl2RedmineCoreTests/TestData/ToggleEntry+TestData.swift
+++ b/Tests/Toggl2RedmineCoreTests/TestData/ToggleEntry+TestData.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Toggl2RedmineCore
+
+extension TogglEntry {
+    static func test(
+        id: Int = 1,
+        description: String = "#1: Issue",
+        start: Date = .init(),
+        duration: Int = 60,
+        tags: [String] = []
+    ) -> TogglEntry {
+        .init(
+            id: id,
+            description: description,
+            start: start,
+            duration: duration,
+            tags: tags
+        )
+    }
+}

--- a/Tests/Toggl2RedmineCoreTests/TogglEntryTests.swift
+++ b/Tests/Toggl2RedmineCoreTests/TogglEntryTests.swift
@@ -1,0 +1,14 @@
+import Toggl2RedmineCore
+import XCTest
+
+final class TogglEntryTests: XCTestCase {
+    func test_isValid_isCaseInsensitive() {
+        XCTAssertFalse(TogglEntry.test(tags: ["SYNCHRONIZED"]).isValid)
+        XCTAssertFalse(TogglEntry.test(tags: ["Synchronized"]).isValid)
+        XCTAssertFalse(TogglEntry.test(tags: ["synchronized"]).isValid)
+    }
+    
+    static var allTests = [
+        ("test_isValid_isCaseInsensitive", test_isValid_isCaseInsensitive),
+    ]
+}

--- a/Tests/Toggl2RedmineCoreTests/XCTestManifests.swift
+++ b/Tests/Toggl2RedmineCoreTests/XCTestManifests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+#if !canImport(ObjectiveC)
+public func allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(TogglEntryTests.allTests),
+    ]
+}
+#endif


### PR DESCRIPTION
If user already had _Synchronized_ tag in Toggl in different capitalization, e.g. _synchronized_, it was not recognized by t2r and it was logged in Redmine multiple times. This PR converts tags to lowercase and compares lowercased variants.

To add ability to import model in tests, it was necessary to create another target that is a library, not executable.